### PR TITLE
support out of core, for ceil operation

### DIFF
--- a/src/main/java/org/apache/sysds/runtime/instructions/OOCInstructionParser.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/OOCInstructionParser.java
@@ -23,10 +23,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.sysds.common.InstructionType;
 import org.apache.sysds.runtime.DMLRuntimeException;
-import org.apache.sysds.runtime.instructions.ooc.AggregateUnaryOOCInstruction;
-import org.apache.sysds.runtime.instructions.ooc.BinaryOOCInstruction;
-import org.apache.sysds.runtime.instructions.ooc.OOCInstruction;
-import org.apache.sysds.runtime.instructions.ooc.ReblockOOCInstruction;
+import org.apache.sysds.runtime.instructions.ooc.*;
 
 public class OOCInstructionParser extends InstructionParser {
 	protected static final Log LOG = LogFactory.getLog(OOCInstructionParser.class.getName());
@@ -51,6 +48,8 @@ public class OOCInstructionParser extends InstructionParser {
 				return ReblockOOCInstruction.parseInstruction(str);
 			case AggregateUnary:
 				return AggregateUnaryOOCInstruction.parseInstruction(str);
+			case Unary:
+				return UnaryOOCInstruction.parseInstruction(str);
 			case Binary:
 				return BinaryOOCInstruction.parseInstruction(str);
 			

--- a/src/main/java/org/apache/sysds/runtime/instructions/OOCInstructionParser.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/OOCInstructionParser.java
@@ -23,7 +23,11 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.sysds.common.InstructionType;
 import org.apache.sysds.runtime.DMLRuntimeException;
-import org.apache.sysds.runtime.instructions.ooc.*;
+import org.apache.sysds.runtime.instructions.ooc.AggregateUnaryOOCInstruction;
+import org.apache.sysds.runtime.instructions.ooc.BinaryOOCInstruction;
+import org.apache.sysds.runtime.instructions.ooc.OOCInstruction;
+import org.apache.sysds.runtime.instructions.ooc.ReblockOOCInstruction;
+import org.apache.sysds.runtime.instructions.ooc.UnaryOOCInstruction;
 
 public class OOCInstructionParser extends InstructionParser {
 	protected static final Log LOG = LogFactory.getLog(OOCInstructionParser.class.getName());

--- a/src/main/java/org/apache/sysds/runtime/instructions/ooc/OOCInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/ooc/OOCInstruction.java
@@ -30,7 +30,7 @@ public abstract class OOCInstruction extends Instruction {
 	protected static final Log LOG = LogFactory.getLog(OOCInstruction.class.getName());
 
 	public enum OOCType {
-		Reblock, AggregateUnary, Binary
+		Reblock, AggregateUnary, Binary, Unary
 	}
 
 	protected final OOCInstruction.OOCType _ooctype;

--- a/src/main/java/org/apache/sysds/runtime/instructions/ooc/UnaryOOCInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/ooc/UnaryOOCInstruction.java
@@ -1,16 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.apache.sysds.runtime.instructions.ooc;
 
-import org.apache.sysds.common.Types;
 import org.apache.sysds.runtime.DMLRuntimeException;
 import org.apache.sysds.runtime.controlprogram.caching.MatrixObject;
 import org.apache.sysds.runtime.controlprogram.context.ExecutionContext;
 import org.apache.sysds.runtime.controlprogram.parfor.LocalTaskQueue;
-import org.apache.sysds.runtime.functionobjects.Builtin;
 import org.apache.sysds.runtime.instructions.InstructionUtils;
 import org.apache.sysds.runtime.instructions.cp.CPOperand;
 import org.apache.sysds.runtime.instructions.spark.data.IndexedMatrixValue;
 import org.apache.sysds.runtime.matrix.data.MatrixBlock;
-import org.apache.sysds.runtime.matrix.operators.Operator;
 import org.apache.sysds.runtime.matrix.operators.UnaryOperator;
 import org.apache.sysds.runtime.util.CommonThreadPool;
 

--- a/src/main/java/org/apache/sysds/runtime/instructions/ooc/UnaryOOCInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/ooc/UnaryOOCInstruction.java
@@ -1,11 +1,19 @@
 package org.apache.sysds.runtime.instructions.ooc;
 
 import org.apache.sysds.common.Types;
+import org.apache.sysds.runtime.DMLRuntimeException;
+import org.apache.sysds.runtime.controlprogram.caching.MatrixObject;
 import org.apache.sysds.runtime.controlprogram.context.ExecutionContext;
+import org.apache.sysds.runtime.controlprogram.parfor.LocalTaskQueue;
 import org.apache.sysds.runtime.instructions.InstructionUtils;
 import org.apache.sysds.runtime.instructions.cp.CPOperand;
+import org.apache.sysds.runtime.instructions.spark.data.IndexedMatrixValue;
+import org.apache.sysds.runtime.matrix.data.MatrixBlock;
 import org.apache.sysds.runtime.matrix.operators.Operator;
 import org.apache.sysds.runtime.matrix.operators.UnaryOperator;
+import org.apache.sysds.runtime.util.CommonThreadPool;
+
+import java.util.concurrent.ExecutorService;
 
 public class UnaryOOCInstruction extends ComputationOOCInstruction {
     private UnaryOperator _uop = null;
@@ -21,11 +29,42 @@ public class UnaryOOCInstruction extends ComputationOOCInstruction {
         CPOperand in1 = new CPOperand(parts[1]);
         CPOperand out = new CPOperand(parts[2]);
 
+        System.out.println("Here at UnaryOOCInstruction parseInstruction");
+
         UnaryOperator uopcode = InstructionUtils.parseUnaryOperator(opcode);
         return new UnaryOOCInstruction(OOCType.Unary, uopcode, in1, out, str, str);
     }
 
     public void processInstruction( ExecutionContext ec ) {
+        UnaryOperator uop = (UnaryOperator) _uop;
+        // Create thread and process the unary operation
+        MatrixObject min = ec.getMatrixObject(input1);
+        LocalTaskQueue<IndexedMatrixValue> qIn = min.getStreamHandle();
+        LocalTaskQueue<IndexedMatrixValue> qOut = new LocalTaskQueue<>();
+        ec.getMatrixObject(output).setStreamHandle(qOut);
+        System.out.println("Here at UnaryOOCInstruction processInstruction ExecutionContext");
 
+        ExecutorService pool = CommonThreadPool.get();
+        try {
+            pool.submit(() -> {
+                IndexedMatrixValue tmp = null;
+                try {
+                    while ((tmp = qIn.dequeueTask()) != LocalTaskQueue.NO_MORE_TASKS) {
+                        IndexedMatrixValue tmpOut = new IndexedMatrixValue();
+                        System.out.println("Here at Inside thread");
+                        tmpOut.set(tmp.getIndexes(),
+                                tmp.getValue().unaryOperations(uop, new MatrixBlock()));
+                        qOut.enqueueTask(tmpOut);
+                    }
+                    qOut.dequeueTask();
+                }
+                catch(Exception ex) {
+                    throw new DMLRuntimeException(ex);
+                }
+            });
+        }
+        finally {
+            pool.shutdown();
+        }
     }
 }

--- a/src/main/java/org/apache/sysds/runtime/instructions/ooc/UnaryOOCInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/ooc/UnaryOOCInstruction.java
@@ -5,6 +5,7 @@ import org.apache.sysds.runtime.DMLRuntimeException;
 import org.apache.sysds.runtime.controlprogram.caching.MatrixObject;
 import org.apache.sysds.runtime.controlprogram.context.ExecutionContext;
 import org.apache.sysds.runtime.controlprogram.parfor.LocalTaskQueue;
+import org.apache.sysds.runtime.functionobjects.Builtin;
 import org.apache.sysds.runtime.instructions.InstructionUtils;
 import org.apache.sysds.runtime.instructions.cp.CPOperand;
 import org.apache.sysds.runtime.instructions.spark.data.IndexedMatrixValue;
@@ -18,8 +19,10 @@ import java.util.concurrent.ExecutorService;
 public class UnaryOOCInstruction extends ComputationOOCInstruction {
     private UnaryOperator _uop = null;
 
-    protected UnaryOOCInstruction(OOCType type, Operator op, CPOperand in1, CPOperand out, String opcode, String istr) {
+    protected UnaryOOCInstruction(OOCType type, UnaryOperator op, CPOperand in1, CPOperand out, String opcode, String istr) {
         super(type, op, in1, out, opcode, istr);
+
+        _uop = op;
     }
 
     public static UnaryOOCInstruction parseInstruction(String str) {

--- a/src/main/java/org/apache/sysds/runtime/instructions/ooc/UnaryOOCInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/ooc/UnaryOOCInstruction.java
@@ -22,7 +22,7 @@ public class UnaryOOCInstruction extends ComputationOOCInstruction {
         CPOperand out = new CPOperand(parts[2]);
 
         UnaryOperator uopcode = InstructionUtils.parseUnaryOperator(opcode);
-        return new UnaryOOCInstruction(OOCType.Unary, uopcode, in1, out, str);
+        return new UnaryOOCInstruction(OOCType.Unary, uopcode, in1, out, str, str);
     }
 
     public void processInstruction( ExecutionContext ec ) {

--- a/src/main/java/org/apache/sysds/runtime/instructions/ooc/UnaryOOCInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/ooc/UnaryOOCInstruction.java
@@ -35,7 +35,7 @@ public class UnaryOOCInstruction extends ComputationOOCInstruction {
         System.out.println("Here at UnaryOOCInstruction parseInstruction");
 
         UnaryOperator uopcode = InstructionUtils.parseUnaryOperator(opcode);
-        return new UnaryOOCInstruction(OOCType.Unary, uopcode, in1, out, str, str);
+        return new UnaryOOCInstruction(OOCType.Unary, uopcode, in1, out, opcode, str);
     }
 
     public void processInstruction( ExecutionContext ec ) {

--- a/src/main/java/org/apache/sysds/runtime/instructions/ooc/UnaryOOCInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/ooc/UnaryOOCInstruction.java
@@ -50,8 +50,6 @@ public class UnaryOOCInstruction extends ComputationOOCInstruction {
         CPOperand in1 = new CPOperand(parts[1]);
         CPOperand out = new CPOperand(parts[2]);
 
-        System.out.println("Here at UnaryOOCInstruction parseInstruction");
-
         UnaryOperator uopcode = InstructionUtils.parseUnaryOperator(opcode);
         return new UnaryOOCInstruction(OOCType.Unary, uopcode, in1, out, opcode, str);
     }
@@ -63,7 +61,6 @@ public class UnaryOOCInstruction extends ComputationOOCInstruction {
         LocalTaskQueue<IndexedMatrixValue> qIn = min.getStreamHandle();
         LocalTaskQueue<IndexedMatrixValue> qOut = new LocalTaskQueue<>();
         ec.getMatrixObject(output).setStreamHandle(qOut);
-        System.out.println("Here at UnaryOOCInstruction processInstruction ExecutionContext");
 
 
         ExecutorService pool = CommonThreadPool.get();
@@ -73,7 +70,6 @@ public class UnaryOOCInstruction extends ComputationOOCInstruction {
                 try {
                     while ((tmp = qIn.dequeueTask()) != LocalTaskQueue.NO_MORE_TASKS) {
                         IndexedMatrixValue tmpOut = new IndexedMatrixValue();
-                        System.out.println("Here at Inside thread");
                         tmpOut.set(tmp.getIndexes(),
                                 tmp.getValue().unaryOperations(uop, new MatrixBlock()));
                         qOut.enqueueTask(tmpOut);

--- a/src/main/java/org/apache/sysds/runtime/instructions/ooc/UnaryOOCInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/ooc/UnaryOOCInstruction.java
@@ -62,14 +62,11 @@ public class UnaryOOCInstruction extends ComputationOOCInstruction {
                                 tmp.getValue().unaryOperations(uop, new MatrixBlock()));
                         qOut.enqueueTask(tmpOut);
                     }
+                    qOut.closeInput();
                 }
                 catch(Exception ex) {
                     throw new DMLRuntimeException(ex);
                 }
-                finally {
-                    qOut.closeInput();
-                }
-
             });
             task.get();
         } catch (ExecutionException | InterruptedException e) {

--- a/src/main/java/org/apache/sysds/runtime/instructions/ooc/UnaryOOCInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/ooc/UnaryOOCInstruction.java
@@ -59,11 +59,14 @@ public class UnaryOOCInstruction extends ComputationOOCInstruction {
                                 tmp.getValue().unaryOperations(uop, new MatrixBlock()));
                         qOut.enqueueTask(tmpOut);
                     }
-                    qOut.dequeueTask();
                 }
                 catch(Exception ex) {
                     throw new DMLRuntimeException(ex);
                 }
+                finally {
+                    qOut.closeInput();
+                }
+
             });
         }
         finally {

--- a/src/main/java/org/apache/sysds/runtime/instructions/ooc/UnaryOOCInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/ooc/UnaryOOCInstruction.java
@@ -26,7 +26,7 @@ public class UnaryOOCInstruction extends ComputationOOCInstruction {
     }
 
     public static UnaryOOCInstruction parseInstruction(String str) {
-        String[] parts = InstructionUtils.getInstructionParts(str);
+        String[] parts = InstructionUtils.getInstructionPartsWithValueType(str);
         InstructionUtils.checkNumFields(parts, 2);
         String opcode = parts[0];
         CPOperand in1 = new CPOperand(parts[1]);

--- a/src/main/java/org/apache/sysds/runtime/instructions/ooc/UnaryOOCInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/ooc/UnaryOOCInstruction.java
@@ -1,0 +1,31 @@
+package org.apache.sysds.runtime.instructions.ooc;
+
+import org.apache.sysds.common.Types;
+import org.apache.sysds.runtime.controlprogram.context.ExecutionContext;
+import org.apache.sysds.runtime.instructions.InstructionUtils;
+import org.apache.sysds.runtime.instructions.cp.CPOperand;
+import org.apache.sysds.runtime.matrix.operators.Operator;
+import org.apache.sysds.runtime.matrix.operators.UnaryOperator;
+
+public class UnaryOOCInstruction extends ComputationOOCInstruction {
+    private UnaryOperator _uop = null;
+
+    protected UnaryOOCInstruction(OOCType type, Operator op, CPOperand in1, CPOperand out, String opcode, String istr) {
+        super(type, op, in1, out, opcode, istr);
+    }
+
+    public static UnaryOOCInstruction parseInstruction(String str) {
+        String[] parts = InstructionUtils.getInstructionParts(str);
+        InstructionUtils.checkNumFields(parts, 2);
+        String opcode = parts[0];
+        CPOperand in1 = new CPOperand(parts[1]);
+        CPOperand out = new CPOperand(parts[2]);
+
+        UnaryOperator uopcode = InstructionUtils.parseUnaryOperator(opcode);
+        return new UnaryOOCInstruction(OOCType.Unary, uopcode, in1, out, str);
+    }
+
+    public void processInstruction( ExecutionContext ec ) {
+
+    }
+}

--- a/src/test/java/org/apache/sysds/test/functions/ooc/UnaryTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/ooc/UnaryTest.java
@@ -86,8 +86,8 @@ public class UnaryTest extends AutomatedTestBase {
 			
 			runTest(true, false, null, -1);
 
-			HashMap<MatrixValue.CellIndex, Double> dmlfile = readDMLMatrixFromOutputDir(OUTPUT_NAME);
-			Double result = dmlfile.get(new MatrixValue.CellIndex(1, 1));
+//			HashMap<MatrixValue.CellIndex, Double> dmlfile = readDMLMatrixFromOutputDir(OUTPUT_NAME);
+//			Double result = dmlfile.get(new MatrixValue.CellIndex(1, 1));
 //			double expected = 0.0;
 //			for(int i = 0; i < rows; i++) {
 //				for(int j = 0; j < cols; j++) {

--- a/src/test/java/org/apache/sysds/test/functions/ooc/UnaryTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/ooc/UnaryTest.java
@@ -86,16 +86,16 @@ public class UnaryTest extends AutomatedTestBase {
 			
 			runTest(true, false, null, -1);
 
-//			HashMap<MatrixValue.CellIndex, Double> dmlfile = readDMLMatrixFromOutputDir(OUTPUT_NAME);
-//			Double result = dmlfile.get(new MatrixValue.CellIndex(1, 1));
-//			double expected = 0.0;
-//			for(int i = 0; i < rows; i++) {
-//				for(int j = 0; j < cols; j++) {
-//					expected += mb.get(i, j) * 7;
-//				}
-//			}
-//
-//			Assert.assertEquals(expected, result, 1e-10);
+			HashMap<MatrixValue.CellIndex, Double> dmlfile = readDMLMatrixFromOutputDir(OUTPUT_NAME);
+			Double result = dmlfile.get(new MatrixValue.CellIndex(1, 1));
+			double expected = 0.0;
+			for(int i = 0; i < rows; i++) {
+				for(int j = 0; j < cols; j++) {
+					expected += Math.ceil(mb.get(i, j));
+				}
+			}
+
+			Assert.assertEquals(expected, result, 1e-10);
 
 			String prefix = Instruction.OOC_INST_PREFIX;
 			Assert.assertTrue("OOC wasn't used for RBLK",

--- a/src/test/java/org/apache/sysds/test/functions/ooc/UnaryTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/ooc/UnaryTest.java
@@ -77,7 +77,7 @@ public class UnaryTest extends AutomatedTestBase {
 			programArgs = new String[] {"-explain", "-stats", "-ooc", 
 				"-args", input(INPUT_NAME), output(OUTPUT_NAME)};
 
-			int rows = 3500, cols = 4;
+			int rows = 3500, cols = 1000;
 			MatrixBlock mb = MatrixBlock.randOperations(rows, cols, 1.0, -1, 1, "uniform", 7);
 			MatrixWriter writer = MatrixWriterFactory.createMatrixWriter(FileFormat.BINARY);
 			writer.writeMatrixToHDFS(mb, input(INPUT_NAME), rows, cols, 1000, rows*cols);

--- a/src/test/java/org/apache/sysds/test/functions/ooc/UnaryTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/ooc/UnaryTest.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sysds.test.functions.ooc;
+
+import org.apache.sysds.common.Opcodes;
+import org.apache.sysds.common.Types;
+import org.apache.sysds.common.Types.FileFormat;
+import org.apache.sysds.common.Types.ValueType;
+import org.apache.sysds.hops.OptimizerUtils;
+import org.apache.sysds.runtime.instructions.Instruction;
+import org.apache.sysds.runtime.io.MatrixWriter;
+import org.apache.sysds.runtime.io.MatrixWriterFactory;
+import org.apache.sysds.runtime.matrix.data.MatrixBlock;
+import org.apache.sysds.runtime.matrix.data.MatrixValue;
+import org.apache.sysds.runtime.meta.MatrixCharacteristics;
+import org.apache.sysds.runtime.util.HDFSTool;
+import org.apache.sysds.test.AutomatedTestBase;
+import org.apache.sysds.test.TestConfiguration;
+import org.apache.sysds.test.TestUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.HashMap;
+
+public class UnaryTest extends AutomatedTestBase {
+
+	private static final String TEST_NAME = "Unary";
+	private static final String TEST_DIR = "functions/ooc/";
+	private static final String TEST_CLASS_DIR = TEST_DIR + UnaryTest.class.getSimpleName() + "/";
+	private static final String INPUT_NAME = "X";
+	private static final String OUTPUT_NAME = "res";
+
+	@Override
+	public void setUp() {
+		TestUtils.clearAssertionInformation();
+		TestConfiguration config = new TestConfiguration(TEST_CLASS_DIR, TEST_NAME);
+		addTestConfiguration(TEST_NAME, config);
+	}
+
+	/**
+	 * Test the sum of scalar multiplication, "sum(X*7)", with OOC backend.
+	 */
+	@Test
+	public void testUnary() {
+		testUnaryOperation(false);
+	}
+	
+	
+	public void testUnaryOperation(boolean rewrite)
+	{
+		Types.ExecMode platformOld = rtplatform;
+		rtplatform = Types.ExecMode.SINGLE_NODE;
+		boolean oldRewrite = OptimizerUtils.ALLOW_ALGEBRAIC_SIMPLIFICATION;
+		OptimizerUtils.ALLOW_ALGEBRAIC_SIMPLIFICATION = rewrite;
+		
+		try {
+			getAndLoadTestConfiguration(TEST_NAME);
+			String HOME = SCRIPT_DIR + TEST_DIR;
+			fullDMLScriptName = HOME + TEST_NAME + ".dml";
+			programArgs = new String[] {"-explain", "-stats", "-ooc", 
+				"-args", input(INPUT_NAME), output(OUTPUT_NAME)};
+
+			int rows = 3500, cols = 4;
+			MatrixBlock mb = MatrixBlock.randOperations(rows, cols, 1.0, -1, 1, "uniform", 7);
+			MatrixWriter writer = MatrixWriterFactory.createMatrixWriter(FileFormat.BINARY);
+			writer.writeMatrixToHDFS(mb, input(INPUT_NAME), rows, cols, 1000, rows*cols);
+			HDFSTool.writeMetaDataFile(input(INPUT_NAME+".mtd"), ValueType.FP64, 
+				new MatrixCharacteristics(rows,cols,1000,rows*cols), FileFormat.BINARY);
+			
+			runTest(true, false, null, -1);
+
+			HashMap<MatrixValue.CellIndex, Double> dmlfile = readDMLMatrixFromOutputDir(OUTPUT_NAME);
+			Double result = dmlfile.get(new MatrixValue.CellIndex(1, 1));
+//			double expected = 0.0;
+//			for(int i = 0; i < rows; i++) {
+//				for(int j = 0; j < cols; j++) {
+//					expected += mb.get(i, j) * 7;
+//				}
+//			}
+//
+//			Assert.assertEquals(expected, result, 1e-10);
+
+			String prefix = Instruction.OOC_INST_PREFIX;
+			Assert.assertTrue("OOC wasn't used for RBLK",
+				heavyHittersContainsString(prefix + Opcodes.RBLK));
+			if(!rewrite)
+				Assert.assertTrue("OOC wasn't used for SUM",
+					heavyHittersContainsString(prefix + Opcodes.MULT));
+			Assert.assertTrue("OOC wasn't used for SUM",
+				heavyHittersContainsString(prefix + Opcodes.UAKP));
+		}
+		catch(Exception ex) {
+			Assert.fail(ex.getMessage());
+		}
+		finally {
+			OptimizerUtils.ALLOW_ALGEBRAIC_SIMPLIFICATION = oldRewrite;
+			resetExecMode(platformOld);
+		}
+	}
+}

--- a/src/test/java/org/apache/sysds/test/functions/ooc/UnaryTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/ooc/UnaryTest.java
@@ -77,7 +77,7 @@ public class UnaryTest extends AutomatedTestBase {
 			programArgs = new String[] {"-explain", "-stats", "-ooc", 
 				"-args", input(INPUT_NAME), output(OUTPUT_NAME)};
 
-			int rows = 3500, cols = 1000;
+			int rows = 1000, cols = 1000;
 			MatrixBlock mb = MatrixBlock.randOperations(rows, cols, 1.0, -1, 1, "uniform", 7);
 			MatrixWriter writer = MatrixWriterFactory.createMatrixWriter(FileFormat.BINARY);
 			writer.writeMatrixToHDFS(mb, input(INPUT_NAME), rows, cols, 1000, rows*cols);
@@ -86,7 +86,7 @@ public class UnaryTest extends AutomatedTestBase {
 			
 			runTest(true, false, null, -1);
 
-//			HashMap<MatrixValue.CellIndex, Double> dmlfile = readDMLMatrixFromOutputDir(OUTPUT_NAME);
+			HashMap<MatrixValue.CellIndex, Double> dmlfile = readDMLMatrixFromOutputDir(OUTPUT_NAME);
 //			Double result = dmlfile.get(new MatrixValue.CellIndex(1, 1));
 //			double expected = 0.0;
 //			for(int i = 0; i < rows; i++) {

--- a/src/test/java/org/apache/sysds/test/functions/ooc/UnaryTest.java
+++ b/src/test/java/org/apache/sysds/test/functions/ooc/UnaryTest.java
@@ -86,7 +86,7 @@ public class UnaryTest extends AutomatedTestBase {
 			
 			runTest(true, false, null, -1);
 
-			HashMap<MatrixValue.CellIndex, Double> dmlfile = readDMLMatrixFromOutputDir(OUTPUT_NAME);
+//			HashMap<MatrixValue.CellIndex, Double> dmlfile = readDMLMatrixFromOutputDir(OUTPUT_NAME);
 //			Double result = dmlfile.get(new MatrixValue.CellIndex(1, 1));
 //			double expected = 0.0;
 //			for(int i = 0; i < rows; i++) {
@@ -100,11 +100,8 @@ public class UnaryTest extends AutomatedTestBase {
 			String prefix = Instruction.OOC_INST_PREFIX;
 			Assert.assertTrue("OOC wasn't used for RBLK",
 				heavyHittersContainsString(prefix + Opcodes.RBLK));
-			if(!rewrite)
-				Assert.assertTrue("OOC wasn't used for SUM",
-					heavyHittersContainsString(prefix + Opcodes.MULT));
-			Assert.assertTrue("OOC wasn't used for SUM",
-				heavyHittersContainsString(prefix + Opcodes.UAKP));
+			Assert.assertTrue("OOC wasn't used for CEIL",
+				heavyHittersContainsString(prefix + Opcodes.CEIL));
 		}
 		catch(Exception ex) {
 			Assert.fail(ex.getMessage());

--- a/src/test/scripts/functions/ooc/Unary.dml
+++ b/src/test/scripts/functions/ooc/Unary.dml
@@ -20,9 +20,9 @@
 #-------------------------------------------------------------
 
 # Read input matrix and operator from command line args
-X = read($1, format="binary");
+X = read($1);
 
 Y = ceil(X);
-
+print(toString(Y))
 # Write the final matrix result
-write(Y, $2, format="binary");
+write(Y, $2);

--- a/src/test/scripts/functions/ooc/Unary.dml
+++ b/src/test/scripts/functions/ooc/Unary.dml
@@ -23,6 +23,7 @@
 X = read($1);
 #print(toString(X))
 Y = ceil(X);
-print(toString(Y))
+#print(toString(Y))
+res = as.matrix(sum(Y));
 # Write the final matrix result
-#write(Y, $2, format="binary");
+write(res, $2);

--- a/src/test/scripts/functions/ooc/Unary.dml
+++ b/src/test/scripts/functions/ooc/Unary.dml
@@ -21,8 +21,8 @@
 
 # Read input matrix and operator from command line args
 X = read($1);
-print(toString(X))
+#print(toString(X))
 Y = ceil(X);
 print(toString(Y))
 # Write the final matrix result
-write(Y, $2, format="binary");
+#write(Y, $2, format="binary");

--- a/src/test/scripts/functions/ooc/Unary.dml
+++ b/src/test/scripts/functions/ooc/Unary.dml
@@ -1,0 +1,32 @@
+#-------------------------------------------------------------
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#-------------------------------------------------------------
+
+# Read input matrix and operator from command line args
+X = read($1, format="binary");
+op = $3;
+
+# Apply the specified unary operation
+if (op == "ceil") {
+  Y = ceil(X);
+}
+
+# Write the final matrix result
+write(Y, $2, format="binary");

--- a/src/test/scripts/functions/ooc/Unary.dml
+++ b/src/test/scripts/functions/ooc/Unary.dml
@@ -21,7 +21,7 @@
 
 # Read input matrix and operator from command line args
 X = read($1);
-
+print(toString(X))
 Y = ceil(X);
 print(toString(Y))
 # Write the final matrix result

--- a/src/test/scripts/functions/ooc/Unary.dml
+++ b/src/test/scripts/functions/ooc/Unary.dml
@@ -25,4 +25,4 @@ print(toString(X))
 Y = ceil(X);
 print(toString(Y))
 # Write the final matrix result
-write(Y, $2);
+write(Y, $2, format="binary");

--- a/src/test/scripts/functions/ooc/Unary.dml
+++ b/src/test/scripts/functions/ooc/Unary.dml
@@ -21,12 +21,8 @@
 
 # Read input matrix and operator from command line args
 X = read($1, format="binary");
-op = $3;
 
-# Apply the specified unary operation
-if (op == "ceil") {
-  Y = ceil(X);
-}
+Y = ceil(X);
 
 # Write the final matrix result
 write(Y, $2, format="binary");


### PR DESCRIPTION
```
ooc_OOC°ceil°_mVar0·MATRIX·FP64°_mVar1·MATRIX·FP64
```

support out of core, for ceil operation.

Normal
---

```c
# EXPLAIN (RUNTIME):
# Memory Budget local/remote = 2100MB/?MB/?MB
# Degree of Parallelism (vcores) local/remote = 8/
PROGRAM ( size CP/MR = 11/0 )
--MAIN PROGRAM
----GENERIC (lines 23-28) [recompile=false]
------CP createvar pREADX target/testTemp/functions/ooc/UnaryTest/in/X false MATRIX binary 3500 4 1000 14000 copy
------CP toString target=pREADX _Var0.SCALAR.STRING
------CP createvar _mVar1 target\testTemp\functions\ooc\UnaryTest\Unary/target/scratch_space//_p62680_10.156.144.127//_t0/temp0 true MATRIX binary 3500 4 1000 -1 copy
------CP ceil pREADX.MATRIX.FP64 _mVar1.MATRIX.FP64 8 false
------CP toString target=_mVar1 _Var2.SCALAR.STRING
------CP print _Var0.SCALAR.STRING.false _Var3.SCALAR.STRING 8
------CP rmvar _Var0
------CP print _Var2.SCALAR.STRING.false _Var4.SCALAR.STRING 8
------CP rmvar _Var2
------CP write _mVar1.MATRIX.FP64 target/testTemp/functions/ooc/UnaryTest/out/res.SCALAR.STRING.true text.SCALAR.STRING.true .SCALAR.STRING.true -1
------CP rmvar _mVar1 _Var3 _Var4

```

```c
SystemDS Statistics:
Total elapsed time:		0.610 sec.
Total compilation time:		0.485 sec.
Total execution time:		0.125 sec.
Cache hits (Mem/Li/WB/FS/HDFS):	2/0/0/0/1.
Cache writes (Li/WB/FS/HDFS):	0/1/0/1.
Cache times (ACQr/m, RLS, EXP):	0.046/0.000/0.002/0.025 sec.
HOP DAGs recompiled (PRED, SB):	0/0.
HOP DAGs recompile time:	0.000 sec.
Total JIT compile time:		0.899 sec.
Total JVM GC count:		1.
Total JVM GC time:		0.012 sec.
Heavy hitter instructions:
 #  Instruction  Time(s)  Count
 1  toString       0.057      2
 2  write          0.027      1
 3  ceil           0.025      1
 4  createvar      0.013      2
 5  rmvar          0.001      3
 6  print          0.000      2


```


with OOC
---

```c
# EXPLAIN (RUNTIME):
# Memory Budget local/remote = 2100MB/?MB/?MB
# Degree of Parallelism (vcores) local/remote = 8/
PROGRAM ( size CP/MR = 9/0 )
--MAIN PROGRAM
----GENERIC (lines 23-28) [recompile=false]
------CP createvar pREADX target/testTemp/functions/ooc/UnaryTest/in/X false MATRIX binary 3500 4 1000 14000 copy
------CP createvar _mVar0 target\testTemp\functions\ooc\UnaryTest\Unary/target/scratch_space//_p71948_10.156.144.127//_t0/temp0 true MATRIX binary 3500 4 1000 14000 copy
------OOC rblk pREADX.MATRIX.FP64 _mVar0.MATRIX.FP64 1000 true
------CP createvar _mVar1 target\testTemp\functions\ooc\UnaryTest\Unary/target/scratch_space//_p71948_10.156.144.127//_t0/temp1 true MATRIX binary 3500 4 1000 -1 copy
------OOC ceil _mVar0.MATRIX.FP64 _mVar1.MATRIX.FP64
------CP rmvar _mVar0
------CP toString target=_mVar1 _Var2.SCALAR.STRING
------CP print _Var2.SCALAR.STRING.false _Var3.SCALAR.STRING 8
------CP rmvar _Var2
------CP write _mVar1.MATRIX.FP64 target/testTemp/functions/ooc/UnaryTest/out/res.SCALAR.STRING.true text.SCALAR.STRING.true .SCALAR.STRING.true -1
------CP rmvar _mVar1 _Var3

```

```c
SystemDS Statistics:
Total elapsed time:		0.539 sec.
Total compilation time:		0.502 sec.
Total execution time:		0.037 sec.
Cache hits (Mem/Li/WB/FS/HDFS):	0/0/0/0/1.
Cache writes (Li/WB/FS/HDFS):	0/0/0/0.
Cache times (ACQr/m, RLS, EXP):	0.000/0.000/0.000/0.000 sec.
HOP DAGs recompiled (PRED, SB):	0/0.
HOP DAGs recompile time:	0.000 sec.
Total JIT compile time:		0.896 sec.
Total JVM GC count:		1.
Total JVM GC time:		0.008 sec.
Heavy hitter instructions:
 #  Instruction                     Time(s)  Count
 1  createvar                         0.012      3
 2  ooc_rblk                          0.001      1
 3  rmvar                             0.000      1
 4  ooc_OOC°ceil°_mVar0·MATRIX·FP6    0.000      1
    4°_mVar1·MATRIX·FP64        
```

