### PR TITLE
add abstract method writeMatrixFromStream

### DIFF
--- a/src/main/java/org/apache/sysds/runtime/compress/io/WriterCompressed.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/io/WriterCompressed.java
@@ -410,7 +410,7 @@ public final class WriterCompressed extends MatrixWriter {
 	}
 
 	@Override
-	public void writeMatrixFromStream(String fname, LocalTaskQueue<IndexedMatrixValue> stream, long rlen, long clen, int blen) {
+	public long writeMatrixFromStream(String fname, LocalTaskQueue<IndexedMatrixValue> stream, long rlen, long clen, int blen) {
 		throw new UnsupportedOperationException("Writing from an OOC stream is not supported for the HDF5 format.");
 	};
 

--- a/src/main/java/org/apache/sysds/runtime/compress/io/WriterCompressed.java
+++ b/src/main/java/org/apache/sysds/runtime/compress/io/WriterCompressed.java
@@ -46,7 +46,9 @@ import org.apache.sysds.runtime.compress.colgroup.dictionary.IDictionary;
 import org.apache.sysds.runtime.compress.lib.CLALibSeparator;
 import org.apache.sysds.runtime.compress.lib.CLALibSeparator.SeparatedGroups;
 import org.apache.sysds.runtime.compress.lib.CLALibSlice;
+import org.apache.sysds.runtime.controlprogram.parfor.LocalTaskQueue;
 import org.apache.sysds.runtime.instructions.spark.CompressionSPInstruction.CompressionFunction;
+import org.apache.sysds.runtime.instructions.spark.data.IndexedMatrixValue;
 import org.apache.sysds.runtime.instructions.spark.utils.RDDConverterUtils;
 import org.apache.sysds.runtime.io.FileFormatProperties;
 import org.apache.sysds.runtime.io.IOUtilFunctions;
@@ -406,5 +408,10 @@ public final class WriterCompressed extends MatrixWriter {
 		}
 
 	}
+
+	@Override
+	public void writeMatrixFromStream(String fname, LocalTaskQueue<IndexedMatrixValue> stream, long rlen, long clen, int blen) {
+		throw new UnsupportedOperationException("Writing from an OOC stream is not supported for the HDF5 format.");
+	};
 
 }

--- a/src/main/java/org/apache/sysds/runtime/instructions/cp/VariableCPInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/cp/VariableCPInstruction.java
@@ -48,7 +48,17 @@ import org.apache.sysds.runtime.frame.data.FrameBlock;
 import org.apache.sysds.runtime.instructions.Instruction;
 import org.apache.sysds.runtime.instructions.InstructionUtils;
 import org.apache.sysds.runtime.instructions.spark.data.IndexedMatrixValue;
-import org.apache.sysds.runtime.io.*;
+import org.apache.sysds.runtime.io.FileFormatProperties;
+import org.apache.sysds.runtime.io.FileFormatPropertiesCSV;
+import org.apache.sysds.runtime.io.FileFormatPropertiesHDF5;
+import org.apache.sysds.runtime.io.FileFormatPropertiesLIBSVM;
+import org.apache.sysds.runtime.io.ListReader;
+import org.apache.sysds.runtime.io.ListWriter;
+import org.apache.sysds.runtime.io.WriterHDF5;
+import org.apache.sysds.runtime.io.WriterMatrixMarket;
+import org.apache.sysds.runtime.io.WriterTextCSV;
+import org.apache.sysds.runtime.io.MatrixWriterFactory;
+import org.apache.sysds.runtime.io.MatrixWriter;
 import org.apache.sysds.runtime.lineage.LineageItem;
 import org.apache.sysds.runtime.lineage.LineageItemUtils;
 import org.apache.sysds.runtime.lineage.LineageTraceable;
@@ -1075,7 +1085,6 @@ public class VariableCPInstruction extends CPInstruction implements LineageTrace
 
 					// 2. Clear its dirty flag and update its file path to the result we just wrote.
 					// This tells the system that the data for this variable now lives in 'fname'.
-//					mo.setFileName(fname);
 					HDFSTool.copyFileOnHDFS(fname, mo.getFileName());
 					mo.setDirty(false);
 
@@ -1094,8 +1103,6 @@ public class VariableCPInstruction extends CPInstruction implements LineageTrace
 				writeHDF5File(ec, fname);
 			else {
 				// Default behavior (text, binary)
-//				MatrixObject mo = ec.getMatrixObject(getInput1().getName());
-//				int blen = Integer.parseInt(getInput4().getName());
 				mo.exportData(fname, fmtStr, new FileFormatProperties(blen));
 			}
 		}

--- a/src/main/java/org/apache/sysds/runtime/instructions/cp/VariableCPInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/cp/VariableCPInstruction.java
@@ -1075,7 +1075,8 @@ public class VariableCPInstruction extends CPInstruction implements LineageTrace
 
 					// 2. Clear its dirty flag and update its file path to the result we just wrote.
 					// This tells the system that the data for this variable now lives in 'fname'.
-					mo.setFileName(fname);
+//					mo.setFileName(fname);
+					HDFSTool.copyFileOnHDFS(fname, mo.getFileName());
 					mo.setDirty(false);
 
 				}

--- a/src/main/java/org/apache/sysds/runtime/instructions/cp/VariableCPInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/cp/VariableCPInstruction.java
@@ -1069,6 +1069,15 @@ public class VariableCPInstruction extends CPInstruction implements LineageTrace
 					MatrixCharacteristics mc = new MatrixCharacteristics(nrows, ncols, blen, totalNnz);
                     HDFSTool.writeMetaDataFile(fname + ".mtd", mo.getValueType(), mc, fmt);
 
+					// 1. Update the metadata of the MatrixObject in the symbol table.
+					mo.updateDataCharacteristics(mc);
+					System.out.println("MO characterstics updated to avoid recompilation");
+
+					// 2. Clear its dirty flag and update its file path to the result we just wrote.
+					// This tells the system that the data for this variable now lives in 'fname'.
+					mo.setFileName(fname);
+					mo.setDirty(false);
+
 				}
 				catch(Exception ex) {
 					throw new DMLRuntimeException("Failed to write OOC stream to " + fname, ex);

--- a/src/main/java/org/apache/sysds/runtime/instructions/cp/VariableCPInstruction.java
+++ b/src/main/java/org/apache/sysds/runtime/instructions/cp/VariableCPInstruction.java
@@ -1062,10 +1062,12 @@ public class VariableCPInstruction extends CPInstruction implements LineageTrace
 
 				try {
 					MatrixWriter writer = MatrixWriterFactory.createMatrixWriter(fmt);
+                    long nrows = mo.getNumRows();
+                    long ncols = mo.getNumColumns();
 
-					writer.writeMatrixFromStream(fname, stream, mo.getNumRows(), mo.getNumColumns(), blen);
-					HDFSTool.writeMetaDataFile(fname + ".mtd", mo.getValueType(),
-							mo.getMetaData().getDataCharacteristics(), fmt);
+					long totalNnz = writer.writeMatrixFromStream(fname, stream, nrows, ncols, blen);
+					MatrixCharacteristics mc = new MatrixCharacteristics(nrows, ncols, blen, totalNnz);
+                    HDFSTool.writeMetaDataFile(fname + ".mtd", mo.getValueType(), mc, fmt);
 
 				}
 				catch(Exception ex) {

--- a/src/main/java/org/apache/sysds/runtime/io/MatrixWriter.java
+++ b/src/main/java/org/apache/sysds/runtime/io/MatrixWriter.java
@@ -23,6 +23,8 @@ import java.io.IOException;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.apache.sysds.runtime.controlprogram.parfor.LocalTaskQueue;
+import org.apache.sysds.runtime.instructions.spark.data.IndexedMatrixValue;
 import org.apache.sysds.runtime.matrix.data.MatrixBlock;
 
 /**
@@ -42,6 +44,20 @@ public abstract class MatrixWriter {
 
 	public abstract void writeMatrixToHDFS( MatrixBlock src, String fname, long rlen, long clen, int blen, long nnz, boolean diag )
 		throws IOException;
+
+	/**
+	 * Consumes an out-of-core stream of matrix blocks and writes them to a single file.
+	 * This method must be implemented by writers that support OOC streaming output.
+	 *
+	 * @param fname The target output filename
+	 * @param stream The OOC stream of matrix blocks to consume
+	 * @param rlen The total number of rows in the matrix
+	 * @param clen The total number of columns in the matrix
+	 * @param blen The block size
+	 * @throws IOException if an I/O error occurs
+	 */
+	public abstract void writeMatrixFromStream(String fname, LocalTaskQueue<IndexedMatrixValue> stream,
+											   long rlen, long clen, int blen) throws IOException;
 	
 	public void setForcedParallel(boolean par) {
 		_forcedParallel = par;

--- a/src/main/java/org/apache/sysds/runtime/io/MatrixWriter.java
+++ b/src/main/java/org/apache/sysds/runtime/io/MatrixWriter.java
@@ -56,7 +56,7 @@ public abstract class MatrixWriter {
 	 * @param blen The block size
 	 * @throws IOException if an I/O error occurs
 	 */
-	public abstract void writeMatrixFromStream(String fname, LocalTaskQueue<IndexedMatrixValue> stream,
+	public abstract long writeMatrixFromStream(String fname, LocalTaskQueue<IndexedMatrixValue> stream,
 											   long rlen, long clen, int blen) throws IOException;
 	
 	public void setForcedParallel(boolean par) {

--- a/src/main/java/org/apache/sysds/runtime/io/WriterBinaryBlock.java
+++ b/src/main/java/org/apache/sysds/runtime/io/WriterBinaryBlock.java
@@ -248,7 +248,8 @@ public class WriterBinaryBlock extends MatrixWriter {
 		long totalNnz = 0;
 		try {
 			// 1. Create Sequence file writer for the final destination file
-			writer = new SequenceFile.Writer(fs, conf, path, MatrixIndexes.class, MatrixBlock.class);
+//			writer = new SequenceFile.Writer(fs, conf, path, MatrixIndexes.class, MatrixBlock.class);
+            writer = SequenceFile.createWriter(fs, conf, path, MatrixIndexes.class, MatrixBlock.class);
 
 			// 2. Loop through OOC stream
 			IndexedMatrixValue i_val =  null;

--- a/src/main/java/org/apache/sysds/runtime/io/WriterBinaryBlock.java
+++ b/src/main/java/org/apache/sysds/runtime/io/WriterBinaryBlock.java
@@ -263,6 +263,7 @@ public class WriterBinaryBlock extends MatrixWriter {
 				totalNnz += mb.getNonZeros();
 
 				double[] denseValues = mb.getDenseBlockValues();
+				System.out.println("totalNnz: " + totalNnz);
 				if (denseValues != null) {
 					for (double v : denseValues) {
 						dostream_data.writeDouble(v);

--- a/src/main/java/org/apache/sysds/runtime/io/WriterBinaryBlock.java
+++ b/src/main/java/org/apache/sysds/runtime/io/WriterBinaryBlock.java
@@ -30,6 +30,8 @@ import org.apache.sysds.conf.ConfigurationManager;
 import org.apache.sysds.hops.OptimizerUtils;
 import org.apache.sysds.runtime.DMLRuntimeException;
 import org.apache.sysds.runtime.compress.CompressedMatrixBlock;
+import org.apache.sysds.runtime.controlprogram.parfor.LocalTaskQueue;
+import org.apache.sysds.runtime.instructions.spark.data.IndexedMatrixValue;
 import org.apache.sysds.runtime.matrix.data.MatrixBlock;
 import org.apache.sysds.runtime.matrix.data.MatrixIndexes;
 import org.apache.sysds.runtime.util.HDFSTool;
@@ -228,4 +230,9 @@ public class WriterBinaryBlock extends MatrixWriter {
 			IOUtilFunctions.closeSilently(writer);
 		}
 	}
+
+	@Override
+	public void writeMatrixFromStream(String fname, LocalTaskQueue<IndexedMatrixValue> stream, long rlen, long clen, int blen) {
+		throw new UnsupportedOperationException("Writing from an OOC stream is not supported for the HDF5 format.");
+	};
 }

--- a/src/main/java/org/apache/sysds/runtime/io/WriterBinaryBlock.java
+++ b/src/main/java/org/apache/sysds/runtime/io/WriterBinaryBlock.java
@@ -19,7 +19,6 @@
 
 package org.apache.sysds.runtime.io;
 
-import java.io.DataInput;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
@@ -40,7 +39,6 @@ import org.apache.sysds.runtime.matrix.data.MatrixBlock;
 import org.apache.sysds.runtime.matrix.data.MatrixIndexes;
 import org.apache.sysds.runtime.util.HDFSTool;
 
-import static org.apache.sysds.runtime.util.HDFSTool.getHDFSDataOutputStream;
 
 public class WriterBinaryBlock extends MatrixWriter {
 	protected int _replication = -1;
@@ -238,7 +236,7 @@ public class WriterBinaryBlock extends MatrixWriter {
 	}
 
 	@Override
-	public void writeMatrixFromStream(String fname, LocalTaskQueue<IndexedMatrixValue> stream, long rlen, long clen, int blen) throws IOException {
+	public long writeMatrixFromStream(String fname, LocalTaskQueue<IndexedMatrixValue> stream, long rlen, long clen, int blen) throws IOException {
 		DataOutputStream dostream_data = null;
 		DataOutputStream dostream_header = null;
 
@@ -249,7 +247,7 @@ public class WriterBinaryBlock extends MatrixWriter {
 		Path finalPath = new Path(fname);
 
 		FileSystem fs = null;
-
+		long totalNnz = 0;
 		try {
 			// PASS 1: Stream to a temporary raw data file and count NNZ
 			fs = IOUtilFunctions.getFileSystem(dataPath);
@@ -258,7 +256,7 @@ public class WriterBinaryBlock extends MatrixWriter {
 //			dostream_data.writeLong(rlen);
 //			dostream_data.writeLong(clen);
 
-			long totalNnz = 0;
+//			long totalNnz = 0;
 			IndexedMatrixValue i_val =  null;
 			while((i_val = stream.dequeueTask()) != LocalTaskQueue.NO_MORE_TASKS) {
 				MatrixBlock mb = (MatrixBlock) i_val.getValue();
@@ -327,6 +325,6 @@ public class WriterBinaryBlock extends MatrixWriter {
 //				if (fs.exists(headerPath)) fs.delete(headerPath, false);
 //			}
 		}
-
+		return totalNnz;
     };
 }

--- a/src/main/java/org/apache/sysds/runtime/io/WriterHDF5.java
+++ b/src/main/java/org/apache/sysds/runtime/io/WriterHDF5.java
@@ -24,8 +24,10 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.sysds.conf.ConfigurationManager;
 import org.apache.sysds.runtime.DMLRuntimeException;
+import org.apache.sysds.runtime.controlprogram.parfor.LocalTaskQueue;
 import org.apache.sysds.runtime.data.DenseBlock;
 import org.apache.sysds.runtime.data.SparseBlock;
+import org.apache.sysds.runtime.instructions.spark.data.IndexedMatrixValue;
 import org.apache.sysds.runtime.io.hdf5.H5;
 import org.apache.sysds.runtime.io.hdf5.H5RootObject;
 import org.apache.sysds.runtime.matrix.data.MatrixBlock;
@@ -129,4 +131,9 @@ public class WriterHDF5 extends MatrixWriter {
 			IOUtilFunctions.closeSilently(bos);
 		}
 	}
+
+	@Override
+	public void writeMatrixFromStream(String fname, LocalTaskQueue<IndexedMatrixValue> stream, long rlen, long clen, int blen) {
+		throw new UnsupportedOperationException("Writing from an OOC stream is not supported for the HDF5 format.");
+	};
 }

--- a/src/main/java/org/apache/sysds/runtime/io/WriterHDF5.java
+++ b/src/main/java/org/apache/sysds/runtime/io/WriterHDF5.java
@@ -133,7 +133,7 @@ public class WriterHDF5 extends MatrixWriter {
 	}
 
 	@Override
-	public void writeMatrixFromStream(String fname, LocalTaskQueue<IndexedMatrixValue> stream, long rlen, long clen, int blen) {
+	public long writeMatrixFromStream(String fname, LocalTaskQueue<IndexedMatrixValue> stream, long rlen, long clen, int blen) {
 		throw new UnsupportedOperationException("Writing from an OOC stream is not supported for the HDF5 format.");
 	};
 }

--- a/src/main/java/org/apache/sysds/runtime/io/WriterMatrixMarket.java
+++ b/src/main/java/org/apache/sysds/runtime/io/WriterMatrixMarket.java
@@ -224,7 +224,7 @@ public class WriterMatrixMarket extends MatrixWriter
 	}
 
 	@Override
-	public void writeMatrixFromStream(String fname, LocalTaskQueue<IndexedMatrixValue> stream, long rlen, long clen, int blen) {
-		throw new UnsupportedOperationException("Writing from an OOC stream is not supported for the HDF5 format.");
+	public long writeMatrixFromStream(String fname, LocalTaskQueue<IndexedMatrixValue> stream, long rlen, long clen, int blen) {
+		throw new UnsupportedOperationException("Writing from an OOC stream is not supported for the MatrixMarket format.");
 	};
 }

--- a/src/main/java/org/apache/sysds/runtime/io/WriterMatrixMarket.java
+++ b/src/main/java/org/apache/sysds/runtime/io/WriterMatrixMarket.java
@@ -35,7 +35,9 @@ import org.apache.hadoop.io.IOUtils;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.sysds.conf.ConfigurationManager;
 import org.apache.sysds.runtime.DMLRuntimeException;
+import org.apache.sysds.runtime.controlprogram.parfor.LocalTaskQueue;
 import org.apache.sysds.runtime.data.DenseBlock;
+import org.apache.sysds.runtime.instructions.spark.data.IndexedMatrixValue;
 import org.apache.sysds.runtime.matrix.data.IJV;
 import org.apache.sysds.runtime.matrix.data.MatrixBlock;
 import org.apache.sysds.runtime.util.HDFSTool;
@@ -220,4 +222,9 @@ public class WriterMatrixMarket extends MatrixWriter
 			throw new IOException(src.toString() + ": No such file or directory");
 		}
 	}
+
+	@Override
+	public void writeMatrixFromStream(String fname, LocalTaskQueue<IndexedMatrixValue> stream, long rlen, long clen, int blen) {
+		throw new UnsupportedOperationException("Writing from an OOC stream is not supported for the HDF5 format.");
+	};
 }

--- a/src/main/java/org/apache/sysds/runtime/io/WriterTextCSV.java
+++ b/src/main/java/org/apache/sysds/runtime/io/WriterTextCSV.java
@@ -345,7 +345,7 @@ public class WriterTextCSV extends MatrixWriter
 	}
 
 	@Override
-	public void writeMatrixFromStream(String fname, LocalTaskQueue<IndexedMatrixValue> stream, long rlen, long clen, int blen) {
-		throw new UnsupportedOperationException("Writing from an OOC stream is not supported for the HDF5 format.");
+	public long writeMatrixFromStream(String fname, LocalTaskQueue<IndexedMatrixValue> stream, long rlen, long clen, int blen) {
+		throw new UnsupportedOperationException("Writing from an OOC stream is not supported for the TextCSV format.");
 	};
 }

--- a/src/main/java/org/apache/sysds/runtime/io/WriterTextCSV.java
+++ b/src/main/java/org/apache/sysds/runtime/io/WriterTextCSV.java
@@ -35,8 +35,10 @@ import org.apache.hadoop.io.IOUtils;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.sysds.conf.ConfigurationManager;
 import org.apache.sysds.runtime.DMLRuntimeException;
+import org.apache.sysds.runtime.controlprogram.parfor.LocalTaskQueue;
 import org.apache.sysds.runtime.data.DenseBlock;
 import org.apache.sysds.runtime.data.SparseBlock;
+import org.apache.sysds.runtime.instructions.spark.data.IndexedMatrixValue;
 import org.apache.sysds.runtime.matrix.data.MatrixBlock;
 import org.apache.sysds.runtime.util.HDFSTool;
 
@@ -341,4 +343,9 @@ public class WriterTextCSV extends MatrixWriter
 			throw new IOException(srcFilePath.toString() + ": No such file or directory");
 		}
 	}
+
+	@Override
+	public void writeMatrixFromStream(String fname, LocalTaskQueue<IndexedMatrixValue> stream, long rlen, long clen, int blen) {
+		throw new UnsupportedOperationException("Writing from an OOC stream is not supported for the HDF5 format.");
+	};
 }

--- a/src/main/java/org/apache/sysds/runtime/io/WriterTextCell.java
+++ b/src/main/java/org/apache/sysds/runtime/io/WriterTextCell.java
@@ -30,7 +30,9 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.sysds.conf.ConfigurationManager;
 import org.apache.sysds.runtime.DMLRuntimeException;
+import org.apache.sysds.runtime.controlprogram.parfor.LocalTaskQueue;
 import org.apache.sysds.runtime.data.DenseBlock;
+import org.apache.sysds.runtime.instructions.spark.data.IndexedMatrixValue;
 import org.apache.sysds.runtime.matrix.data.IJV;
 import org.apache.sysds.runtime.matrix.data.MatrixBlock;
 import org.apache.sysds.runtime.util.HDFSTool;
@@ -137,4 +139,9 @@ public class WriterTextCell extends MatrixWriter
 				br.write(IOUtilFunctions.EMPTY_TEXT_LINE);
 		}
 	}
+
+	@Override
+	public void writeMatrixFromStream(String fname, LocalTaskQueue<IndexedMatrixValue> stream, long rlen, long clen, int blen) {
+		throw new UnsupportedOperationException("Writing from an OOC stream is not supported for the HDF5 format.");
+	};
 }

--- a/src/main/java/org/apache/sysds/runtime/io/WriterTextCell.java
+++ b/src/main/java/org/apache/sysds/runtime/io/WriterTextCell.java
@@ -141,7 +141,7 @@ public class WriterTextCell extends MatrixWriter
 	}
 
 	@Override
-	public void writeMatrixFromStream(String fname, LocalTaskQueue<IndexedMatrixValue> stream, long rlen, long clen, int blen) {
-		throw new UnsupportedOperationException("Writing from an OOC stream is not supported for the HDF5 format.");
+	public long writeMatrixFromStream(String fname, LocalTaskQueue<IndexedMatrixValue> stream, long rlen, long clen, int blen) {
+		throw new UnsupportedOperationException("Writing from an OOC stream is not supported for the TextCell format.");
 	};
 }

--- a/src/main/java/org/apache/sysds/runtime/io/WriterTextLIBSVM.java
+++ b/src/main/java/org/apache/sysds/runtime/io/WriterTextLIBSVM.java
@@ -28,8 +28,10 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.sysds.conf.ConfigurationManager;
 import org.apache.sysds.runtime.DMLRuntimeException;
+import org.apache.sysds.runtime.controlprogram.parfor.LocalTaskQueue;
 import org.apache.sysds.runtime.data.DenseBlock;
 import org.apache.sysds.runtime.data.SparseBlock;
+import org.apache.sysds.runtime.instructions.spark.data.IndexedMatrixValue;
 import org.apache.sysds.runtime.matrix.data.MatrixBlock;
 import org.apache.sysds.runtime.util.HDFSTool;
 
@@ -156,4 +158,9 @@ public class WriterTextLIBSVM extends MatrixWriter {
 		sb.append(_props.getIndexDelim());
 		sb.append(value);
 	}
+
+	@Override
+	public void writeMatrixFromStream(String fname, LocalTaskQueue<IndexedMatrixValue> stream, long rlen, long clen, int blen) {
+		throw new UnsupportedOperationException("Writing from an OOC stream is not supported for the HDF5 format.");
+	};
 }

--- a/src/main/java/org/apache/sysds/runtime/io/WriterTextLIBSVM.java
+++ b/src/main/java/org/apache/sysds/runtime/io/WriterTextLIBSVM.java
@@ -160,7 +160,7 @@ public class WriterTextLIBSVM extends MatrixWriter {
 	}
 
 	@Override
-	public void writeMatrixFromStream(String fname, LocalTaskQueue<IndexedMatrixValue> stream, long rlen, long clen, int blen) {
-		throw new UnsupportedOperationException("Writing from an OOC stream is not supported for the HDF5 format.");
+	public long writeMatrixFromStream(String fname, LocalTaskQueue<IndexedMatrixValue> stream, long rlen, long clen, int blen) {
+		throw new UnsupportedOperationException("Writing from an OOC stream is not supported for the LIBSVM format.");
 	};
 }

--- a/src/test/scripts/functions/ooc/Unary.dml
+++ b/src/test/scripts/functions/ooc/Unary.dml
@@ -22,8 +22,8 @@
 # Read input matrix and operator from command line args
 X = read($1);
 #print(toString(X))
-Y = ceil(X);
+res = ceil(X);
 #print(toString(Y))
-res = as.matrix(sum(Y));
+#res = as.matrix(sum(Y));
 # Write the final matrix result
-write(res, $2);
+write(res, $2, format="binary");


### PR DESCRIPTION


promise pipeline

```mermaid
graph TD
    subgraph DML Script - Building the Plan
        A[X = read] --> B[res = ceilX] --> C[writeres];
    end

    subgraph SystemDS Runtime - Executing the Plan
        D[ooc_rblk for X] -- Creates Promise A --> E;
        E[ooc_ceil for res] -- Takes Promise A, Creates Promise B --> F;
        F[CP_write for res] -- Consumes Promise B --> G[Final File on Disk];
    end

    subgraph What's Actually Happening
        H(<b>At this point, no data has been computed.</b><br/>'res' is just a plan.) --> I{<b>The 'write' instruction starts the pipeline.</b><br/>It pulls data block-by-block.};
        I --> J(<b>Data for 'res' is generated LIVE</b><br/>as the 'write' instruction requests it.);
    end

    A --> D;
    B --> E;
    C --> F;
```